### PR TITLE
Google AdSense-Skript in HTML-Head eingefügt

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DO1FFE Homepage</title>
     <link rel="stylesheet" href="/static/style.css">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9376188585752918"
+     crossorigin="anonymous"></script>
 </head>
 <body>
     <header>


### PR DESCRIPTION
### Motivation
- Das Google AdSense-Skript soll im `<head>` der Seite geladen werden, um Anzeigen korrekt und asynchron einzubinden.

### Description
- In `templates/index.html` wurde das angegebene `<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9376188585752918" crossorigin="anonymous"></script>` unmittelbar vor `</head>` eingefügt.
- Das `async`-Attribut und `crossorigin="anonymous"` wurden wie vorgegeben übernommen.

### Testing
- `python -m compileall app.py templates/index.html` wurde ausgeführt und hat erfolgreich kompiliert.
- Ein Flask-Test mit `app.test_client()` prüfte, dass die Startseite `HTTP 200` liefert und die `src`-URL sowie `crossorigin="anonymous"` im HTML vorhanden sind; der Test war erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d823304d48321954b5c1ec76412d8)