### PR TITLE
[codex] Promote MeshCore Essen and tighten mobile layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -700,6 +700,56 @@ h3 {
   min-height: 260px;
 }
 
+.promo-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 42px;
+}
+
+.promo-card {
+  display: flex;
+  min-height: 350px;
+  flex-direction: column;
+  padding: 32px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--white);
+  box-shadow: 0 10px 30px rgba(10, 21, 24, 0.06);
+}
+
+.promo-card--accent {
+  color: var(--white);
+  border-color: transparent;
+  background:
+    linear-gradient(135deg, rgba(0, 159, 147, 0.86), rgba(19, 35, 38, 0.94)),
+    #132326;
+}
+
+.promo-card__tag {
+  margin-bottom: 24px;
+  color: var(--red);
+  font-size: 0.73rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.promo-card p {
+  margin: 16px 0 28px;
+  color: var(--ink-2);
+}
+
+.promo-card--accent p,
+.promo-card--accent .promo-card__tag {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.promo-card .button {
+  align-self: flex-start;
+  margin-top: auto;
+}
+
 .page-hero {
   position: relative;
   display: grid;
@@ -1005,6 +1055,7 @@ h3 {
   .topic-index,
   .note-grid,
   .detail-grid,
+  .promo-grid,
   .repo-grid,
   .article-layout,
   .repo-highlight,
@@ -1062,6 +1113,10 @@ h3 {
 
   h2 {
     font-size: clamp(1.8rem, 10vw, 3rem);
+  }
+
+  .page-hero h1 {
+    font-size: clamp(2.35rem, 11vw, 3.4rem);
   }
 
   .hero__actions,

--- a/templates/github.html
+++ b/templates/github.html
@@ -7,7 +7,7 @@
 <section class="page-hero page-hero--code">
   <div class="page-hero__content reveal">
     <p class="eyebrow">github.com/do1ffe</p>
-    <h1>Repos als Basteltisch, Logbuch und Werkzeugkasten.</h1>
+    <h1>Repos als Basteltisch, Logbuch und Werkzeug</h1>
     <p>
       33 oeffentliche Repositories zeigen ziemlich gut, worum es hier geht:
       Python-lastige Tools, Funktechnik, Vereinshelfer, Dashboards, MeshCore und

--- a/templates/meshcore.html
+++ b/templates/meshcore.html
@@ -14,8 +14,9 @@
       und Technikmenschen so interessant.
     </p>
     <div class="hero__actions">
-      <a class="button button--primary" href="https://meshcore.co.uk/" target="_blank" rel="noopener noreferrer">MeshCore Website</a>
-      <a class="button button--ghost" href="https://docs.meshcore.io/faq/" target="_blank" rel="noopener noreferrer">Dokumentation</a>
+      <a class="button button--primary" href="https://meshcore-essen.de/" target="_blank" rel="noopener noreferrer">MeshCore-Essen</a>
+      <a class="button button--ghost" href="https://corescope.lima11.de/#/home" target="_blank" rel="noopener noreferrer">CoreScope Essen live</a>
+      <a class="button button--ghost" href="https://docs.meshcore.io/faq/" target="_blank" rel="noopener noreferrer">MeshCore Docs</a>
     </div>
   </div>
 </section>
@@ -37,10 +38,45 @@
       Softwaredenken zusammenbringt. Ein Node ist Hardware. Ein Paket ist Funk.
       Ein Monitor ist Software. Und wenn etwas nicht ankommt, beginnt die Fehlersuche.
     </p>
+    <p>
+      In Essen wird das Thema besonders greifbar: MeshCore-Essen buendelt den lokalen
+      Einstieg rund um 868 MHz und #essen, waehrend CoreScope Essen die Aktivitaet des
+      Netzes sichtbar macht. Das ist nicht nur ein Link fuer Eingeweihte, sondern ein
+      guter Startpunkt fuer alle, die sehen wollen, ob hier gerade wirklich etwas funkt.
+    </p>
   </article>
   <aside class="feature__media reveal">
     <img src="{{ url_for('static', filename='assets/meshcore-lora.svg') }}" alt="Abstrakte Darstellung eines LoRa-Mesh-Netzes mit verbundenen Nodes">
   </aside>
+</section>
+
+<section class="section content-section mesh-promo">
+  <div class="section__heading reveal">
+    <p class="eyebrow">Essen im Mesh</p>
+    <h2>Der lokale Einstieg und der Live-Blick gehoeren direkt nach vorne.</h2>
+  </div>
+  <div class="promo-grid">
+    <article class="promo-card promo-card--accent reveal">
+      <span class="promo-card__tag">868 MHz / #essen</span>
+      <h3>MeshCore-Essen</h3>
+      <p>
+        Die kompakte Anlaufstelle fuer das Essener MeshCore-Umfeld: Schnellstart,
+        regionale Links, MeshMapper NRW, Mesh Rheinland, OV L11 und weitere Einstiege
+        fuer Menschen, die nicht erst zehn Tabs aufmachen wollen.
+      </p>
+      <a class="button button--primary" href="https://meshcore-essen.de/" target="_blank" rel="noopener noreferrer">meshcore-essen.de oeffnen</a>
+    </article>
+    <article class="promo-card reveal">
+      <span class="promo-card__tag">Live-Analyse</span>
+      <h3>CoreScope Essen</h3>
+      <p>
+        CoreScope zeigt das Netz als beobachtbares System: Pakete, Karte, Kanaele,
+        Nodes, Traces, Observer und Analytics. Genau die richtige Ansicht, wenn aus
+        "muesste gehen" ein "ich sehe es" werden soll.
+      </p>
+      <a class="button button--primary" href="https://corescope.lima11.de/#/home" target="_blank" rel="noopener noreferrer">CoreScope Essen starten</a>
+    </article>
+  </div>
 </section>
 
 <section class="section content-section">
@@ -59,7 +95,7 @@
     </article>
     <article class="detail-card reveal">
       <h3>Monitoring</h3>
-      <p>Tools wie CoreScope oder ein MeshCore-Netzwerkmonitor machen sichtbar, welche Nodes aktiv sind.</p>
+      <p>CoreScope Essen und ein MeshCore-Netzwerkmonitor machen sichtbar, welche Nodes aktiv sind.</p>
     </article>
     <article class="detail-card reveal">
       <h3>Amateurfunk-Denke</h3>
@@ -77,6 +113,7 @@
     <a href="https://github.com/DO1FFE/CoreScope" target="_blank" rel="noopener noreferrer">CoreScope · MeshCore analyzer</a>
     <a href="https://github.com/DO1FFE/meshcore-network-monitor" target="_blank" rel="noopener noreferrer">meshcore-network-monitor</a>
     <a href="https://github.com/DO1FFE/MeshCore" target="_blank" rel="noopener noreferrer">MeshCore fork</a>
+    <a href="https://corescope.lima11.de/#/home" target="_blank" rel="noopener noreferrer">CoreScope Essen live ansehen</a>
   </div>
 </section>
 

--- a/templates/startseite.html
+++ b/templates/startseite.html
@@ -122,7 +122,8 @@
       <p>
         LoRa-Mesh ist spannend, weil es nicht perfekt und glatt ist. Nodes verschwinden,
         Pakete nehmen Umwege, Reichweite ist Standortphysik. Genau deshalb sind
-        Monitor, Analyzer und Live-Visualisierung so nuetzlich.
+        MeshCore-Essen als lokaler Einstieg und CoreScope Essen als Live-Visualisierung
+        so nuetzlich.
       </p>
       <a href="{{ url_for('meshcore') }}">MeshCore-Thema</a>
     </article>

--- a/templates/tesla_dashboard.html
+++ b/templates/tesla_dashboard.html
@@ -7,7 +7,7 @@
 <section class="page-hero page-hero--tesla">
   <div class="page-hero__content reveal">
     <p class="eyebrow">tesla.do1ffe.de · V1.0.1420</p>
-    <h1>Ein eigenes Cockpit fuer Fahrzeugdaten.</h1>
+    <h1>Ein eigenes Cockpit fuer Fahrzeugdaten</h1>
     <p>
       Das Tesla-Dashboard ist kein Deko-Screen, sondern eine praktische Anzeige:
       Fahrzeugauswahl, Dashboard, Statistik, Kartenansicht, Zustandsdaten und

--- a/tests/test_routen.py
+++ b/tests/test_routen.py
@@ -37,3 +37,14 @@ def test_githubseite_enthaelt_repo_auswahl():
     assert "CoreScope" in html
     assert "meshcore-network-monitor" in html
     assert "https://github.com/do1ffe" in html
+
+
+def test_meshcoreseite_bewirbt_lokale_einstiege():
+    klient = app.test_client()
+    antwort = klient.get("/meshcore")
+    html = antwort.get_data(as_text=True)
+
+    assert "https://meshcore-essen.de/" in html
+    assert "https://corescope.lima11.de/#/home" in html
+    assert "MeshCore-Essen" in html
+    assert "CoreScope Essen" in html


### PR DESCRIPTION
## Summary

- Promotes MeshCore-Essen and CoreScope Essen prominently on the MeshCore page.
- Adds a dedicated local MeshCore promo section with direct CTAs for `meshcore-essen.de` and CoreScope Essen.
- Updates the homepage MeshCore teaser and adds route coverage for the new local MeshCore links.
- Tightens page hero typography for very small mobile displays and adjusts two headings that wrapped poorly at 320px.

## Validation

- `python -m pytest` -> 4 passed
- Browser preview at `http://127.0.0.1:8020/`
- Mobile sweep at 375x667 and 320x568 across `/`, `/ov-l11`, `/tesla-dashboard`, `/github`, `/meshcore`, and `/kontakt`
- Checked mobile hamburger visibility on every route and browser console warnings/errors stayed at 0