### PR TITLE
[codex] FunkBruecke-Webseite auf v0.9.242 aktualisieren

### DIFF
--- a/app.py
+++ b/app.py
@@ -62,7 +62,7 @@ FUNKBRUECKE_DOWNLOAD_ARTEFAKTE = [
         "titel": "Bedienungsanleitung",
         "dateiname": "FunkBruecke-Bedienungsanleitung-latest.pdf",
         "typ": "PDF",
-        "beschreibung": "Kurzer Einstieg mit echten Programmansichten, FB1-Live-RX, FB2-Auto-RX, Warteschlange, gehärteter Sendeautomatik, Auto-OK, Audio-QSO-Kette von 2-FSK bis 32-MFSK, FB2-Mesh-Automatik bis 16-MFSK, Gesprächszustand, RX-Sortierung und wichtigsten Handgriffen.",
+        "beschreibung": "Kurzer Einstieg mit echten Programmansichten, FB1-Live-RX, FB2-Auto-RX, Warteschlange, gehärteter Sendeautomatik, Auto-OK, Audio-QSO-Kette von 2-FSK bis 32-MFSK, FB2-Mesh-Automatik bis 16-MFSK, Rückweg-ACK bis zum Ursprung, Gesprächszustand, RX-Sortierung und wichtigsten Handgriffen.",
         "primär": False,
     },
     {
@@ -78,7 +78,7 @@ FUNKBRUECKE_DOWNLOAD_ARTEFAKTE = [
         "titel": "FB2-Übertragung",
         "dateiname": "FB2-Uebertragung.md",
         "typ": "Markdown",
-        "beschreibung": "Technischer Stand zur FB2-Modulation, Paketübertragung, Gesprächszustand, RX-Härtung, RX-Sortierung, FB2-Auto-RX mit Audiopufferprüfung, geprüfter Warteschlangen-Sendeautomatik, Audio-QSO-Kette von 2-FSK bis 32-MFSK, Timeout-Wiederholung und FB2-Mesh-Automatik bis 16-MFSK.",
+        "beschreibung": "Technischer Stand zur FB2-Modulation, Paketübertragung, Gesprächszustand, RX-Härtung, RX-Sortierung, FB2-Auto-RX mit Audiopufferprüfung, geprüfter Warteschlangen-Sendeautomatik, Audio-QSO-Kette von 2-FSK bis 32-MFSK, Timeout-Wiederholung, FB2-Mesh-Automatik bis 16-MFSK und Ende-zu-Ende-Zustellbestätigung.",
         "primär": False,
     },
     {

--- a/templates/funkbruecke.html
+++ b/templates/funkbruecke.html
@@ -67,6 +67,8 @@
       Kanalprüfung, FB1-Horchfenster, Sendesicherheit oder freie TX-Lage noch fehlen.
       Wenn diese Kette passt und die FB2-Mesh-Automatik bewusst freigegeben ist, reiht
       FunkBrücke den nächsten Hop als FB2-Mesh-Auftrag bis 16-MFSK in die Warteschlange ein.
+      Am Ziel erzeugt das Mesh eine Ende-zu-Ende-Zustellbestätigung, die als eigenes
+      Rückweg-Paket über passende Nachbarn bis zum Ursprung zurückläuft.
     </p>
     <p>
       Das Mesh-Prinzip ist der Kern für den späteren Ausbau: Jede Station soll nicht nur
@@ -88,7 +90,7 @@
       <div><dt>Funkgerät</dt><dd>Yaesu FT-991A</dd></div>
       <div><dt>Betriebsart</dt><dd>FB2 senden/empfangen mit Modusleiter bis 32-MFSK, Planung bis OFDM</dd></div>
       <div><dt>Funkweg</dt><dd>SSB schmalbandig, FM für breitere Modi</dd></div>
-      <div><dt>Testbetrieb</dt><dd>Einfachbetrieb mit Warteschlange, automatischem Senden und Empfangen, OK/Wiederholen, Timeout-Wiederholung, FB2-RX bis 32-MFSK, Zwei-Instanzen-Test, FT-991A-Praxistest, Feldnachweisvorschlag, Feldnachweis-Speicherung und bewusst freigebbarer FB2-Mesh-Automatik bis 16-MFSK</dd></div>
+      <div><dt>Testbetrieb</dt><dd>Einfachbetrieb mit Warteschlange, automatischem Senden und Empfangen, OK/Wiederholen, Timeout-Wiederholung, FB2-RX bis 32-MFSK, Zwei-Instanzen-Test, FT-991A-Praxistest, Feldnachweisvorschlag, Feldnachweis-Speicherung und bewusst freigebbarer FB2-Mesh-Automatik bis 16-MFSK mit Rückweg-ACK bis zum Ursprung</dd></div>
     </dl>
   </aside>
 </section>
@@ -227,7 +229,8 @@
       Nachweis nach passendem Paket und OK vorschlagen, laden und bewusst speichern.
       Bei aktivierter FB2-Mesh-Automatik wird ein passender Transitauftrag automatisch
       bis 16-MFSK in die Warteschlange gelegt; breitere Modi bleiben weiter ein
-      Labor- und Feldfreigabethema.
+      Labor- und Feldfreigabethema. Zustellbestätigungen laufen als FB2-Mesh-Rückweg
+      bis zum Ursprung zurück und schließen dort den offenen Auftrag sichtbar ab.
     </p>
   </article>
   <aside class="fact-panel reveal">
@@ -239,7 +242,7 @@
       <li>Empfangene Pakete verständlich als Nachricht, OK, Wiederholen oder Problem anzeigen.</li>
       <li>Bei fehlender Antwort eine eindeutige Wiederholung vorbereiten, statt blind erneut zu senden.</li>
       <li>Vor echten Funkversuchen denselben Ablauf lokal mit zwei Programmfenstern testen.</li>
-      <li>Mesh-Routen nutzen, damit Stationen bei Freigabe automatisch bis 16-MFSK weiterleiten können.</li>
+      <li>Mesh-Routen nutzen, damit Stationen bei Freigabe automatisch bis 16-MFSK weiterleiten und Zustellbestätigungen zurückführen können.</li>
       <li>Dokumentation, Screenshots und Downloads passend zum aktuellen Prototypstand bereitstellen.</li>
     </ul>
   </aside>
@@ -256,7 +259,7 @@
       Moduswahl, Wiederholungslimit, RX-Härtung, Gesprächsabschluss, Auto-RX-Status,
       FB1-Live-RX, FB2-Auto-RX, Sendeautomatik-Praxisstatus, Zwei-Stationen-Livepraxis, Feldtestprotokoll, Zwei-Fenster-Rundlauf,
       direkte FB2-Gesprächsaktionen, Feldnachweisvorschlag, Feldnachweis-Speicherung, FB2-Mesh-Automatikfreigabe, Technik und Diagnose,
-      Vor-TX-Prüfung und Dokumentation. Die wichtigsten
+      Vor-TX-Prüfung, Rückweg-ACK und Dokumentation. Die wichtigsten
       Einstellungen liegen oben in der Menüzeile; im Einfachbetrieb führen Hauptleiste,
       Automatik prüfen und die FB2-Karte durch Einreihen, Prüfung, Senden, Empfangen
       und Antworten.
@@ -275,7 +278,7 @@
   <div class="funkbruecke-screenshot-grid">
     <figure class="reveal">
       <img src="{{ url_for('static', filename='assets/funkbruecke-uebersicht.png') }}" alt="Markierte Übersicht der FunkBrücke-Oberfläche">
-      <figcaption>Übersicht mit Menüzeile, Profil, Wasserfall, Hauptfluss, Sendefreigabe, Warteschlange, gehärteter Sendeautomatik, Gesprächszustand, FB1-Live-RX, FB2-Auto-RX, Live-RX-Praxiskette, Feldnachweisvorschlag, Feldnachweis-Speicherung, FB2-Mesh-Automatikfreigabe, Zwei-Stationen-Livepraxis, Zwei-Fenster-Rundlauf, Schrittliste und Abnahme.</figcaption>
+      <figcaption>Übersicht mit Menüzeile, Profil, Wasserfall, Hauptfluss, Sendefreigabe, Warteschlange, gehärteter Sendeautomatik, Gesprächszustand, FB1-Live-RX, FB2-Auto-RX, Live-RX-Praxiskette, Feldnachweisvorschlag, Feldnachweis-Speicherung, FB2-Mesh-Automatikfreigabe, Rückweg-ACK, Zwei-Stationen-Livepraxis, Zwei-Fenster-Rundlauf, Schrittliste und Abnahme.</figcaption>
     </figure>
     <figure class="reveal">
       <img src="{{ url_for('static', filename='assets/funkbruecke-fb2-test-tx.png') }}" alt="Markierter Bereich für FB2 senden und empfangen">
@@ -365,6 +368,8 @@
       oder freie TX-Lage noch fehlen. Bei bewusst aktivierter Freigabe werden passende
       FB2-Mesh-Aufträge automatisch bis 16-MFSK in die Warteschlange gelegt. Nicht als
       nächster Hop adressierte Stationen hören nur mit und leiten nicht weiter.
+      Erreicht ein Paket sein Ziel, entsteht eine Zustellbestätigung als eigenes
+      Mesh-Paket zurück zum Ursprung; Steuerpakete erzeugen keine ACK-Kette.
       Im Mesh helfen Nachbarstationen, die schnellste und zuverlässigste Übertragung
       passend zur aktuellen Verbindung auszuwählen.
     </p>
@@ -388,6 +393,7 @@
       <li>FB2-/FB2L-Treffer werden für Mesh-Beobachtung und Nachbartabellen angedockt.</li>
       <li>Fremde FB2-Ziele werden als Mesh-Kandidaten bewertet; die Freigabekette prüft gespeicherten Feldnachweis, Bedienfreigabe, Kanalprüfung, Horchfenster, Sendesicherheit und freie TX-Lage.</li>
       <li>Bei bewusster Freigabe werden FB2-Mesh-Textaufträge und Transitpakete automatisch bis 16-MFSK in die Warteschlange gelegt.</li>
+      <li>FB2-Mesh-Zustellbestätigungen laufen über denselben Freigabepfad zurück bis zum Ursprung.</li>
       <li>Nur die als nächster Hop adressierte Station verarbeitet ein FB2-Mesh-Paket aktiv; andere Stationen beobachten den Rahmen nur.</li>
       <li>SSB bleibt schmalbandig, FM kann später breitere Modi besser aufnehmen.</li>
       <li>Mesh-Kurzpakete halten Nachbarn, Geschwindigkeit und Erreichbarkeit aktuell.</li>

--- a/tests/test_routen.py
+++ b/tests/test_routen.py
@@ -199,7 +199,7 @@ def test_funkbruecke_seite_zeigt_aktuellen_prototypstand():
 
     assert antwort.status_code == 200
     assert "Derzeit noch ein Prototyp" in html
-    assert "v0.9.241" in html
+    assert "v0.9.242" in html
     assert "FB1-Live-RX" in html
     assert "FB2-Auto-RX" in html
     assert "Text eingeben, Zielrufzeichen wählen" in html
@@ -210,6 +210,9 @@ def test_funkbruecke_seite_zeigt_aktuellen_prototypstand():
     assert "Timeout-Wiederholung" in html
     assert "Mesh-Freigabekette" in html
     assert "FB2-Mesh-Automatik" in html
+    assert "Rückweg-ACK" in html
+    assert "Zustellbestätigungen" in html
+    assert "bis zum Ursprung" in html
     assert "16-MFSK" in html
     assert "nächster Hop adressierte Station" in html
     assert "Feldnachweis" in html


### PR DESCRIPTION
## Änderungen

- FunkBrücke-Seite erklärt den aktuellen v0.9.242-Prototypstand mit FB2-Mesh-Rückweg-ACK bis zum Ursprung.
- Download-Dokumentbeschreibungen nennen Rückweg-ACK und Ende-zu-Ende-Zustellbestätigung.
- Seitentest prüft v0.9.242, Prototyp-Hinweis, Mesh-Freigabekette, Rückweg-ACK und klare Nicht-Changelog-Darstellung.

## Validierung

- `pytest -q` -> 34/34 grün
